### PR TITLE
fix: expose tenantId on subscription() ARM function and REST endpoint (#162)

### DIFF
--- a/Services/Topaz.Service.ResourceManager/Models/SubscriptionMetadata.cs
+++ b/Services/Topaz.Service.ResourceManager/Models/SubscriptionMetadata.cs
@@ -8,12 +8,14 @@ public record SubscriptionMetadata
 {
     public string Id { get; init; }
     public string SubscriptionId { get; init; }
+    public string TenantId { get; init; }
     public string DisplayName { get; init; }
 
     public SubscriptionMetadata(SubscriptionIdentifier subscriptionIdentifier, string displayName = "")
     {
         Id = $"/subscriptions/{subscriptionIdentifier.Value}";
         SubscriptionId = subscriptionIdentifier.Value.ToString();
+        TenantId = GlobalSettings.DefaultTenantId;
         DisplayName = displayName;
     }
 

--- a/Services/Topaz.Service.Subscription/Models/Responses/GetSubscriptionResponse.cs
+++ b/Services/Topaz.Service.Subscription/Models/Responses/GetSubscriptionResponse.cs
@@ -11,6 +11,7 @@ internal sealed class GetSubscriptionResponse
         {
             Id = subscription.Id,
             SubscriptionId = subscription.SubscriptionId,
+            TenantId = subscription.TenantId,
             DisplayName = subscription.DisplayName,
             State = subscription.State,
             Tags = subscription.Tags
@@ -19,6 +20,7 @@ internal sealed class GetSubscriptionResponse
 
     public string? Id { get; set; }
     public string? SubscriptionId { get; set; }
+    public string? TenantId { get; set; }
     public string? DisplayName { get; set; }
     public string? State { get; set; }
     public IDictionary<string, string>? Tags { get; set; }

--- a/Services/Topaz.Service.Subscription/Models/Subscription.cs
+++ b/Services/Topaz.Service.Subscription/Models/Subscription.cs
@@ -15,6 +15,7 @@ public sealed class Subscription
     }
     
     public string SubscriptionId { get; init; }
+    public string TenantId { get; init; } = GlobalSettings.DefaultTenantId;
     public string? DisplayName { get; set; }
     public string State { get; set; } = "Enabled";
     public IDictionary<string, string> Tags { get; set; }
@@ -31,6 +32,7 @@ public sealed class Subscription
     {
         Id = $"/subscriptions/{subscriptionIdentifier}";
         SubscriptionId = subscriptionIdentifier.ToString();
+        TenantId = GlobalSettings.DefaultTenantId;
         DisplayName = displayName;
         Tags = tags ?? new Dictionary<string, string>();
     }

--- a/Topaz.Tests.AzureCLI/SubscriptionTests.cs
+++ b/Topaz.Tests.AzureCLI/SubscriptionTests.cs
@@ -1,0 +1,16 @@
+using Topaz.Shared;
+
+namespace Topaz.Tests.AzureCLI;
+
+public class SubscriptionTests : TopazFixture
+{
+    [Test]
+    public async Task SubscriptionTests_WhenAccountShowIsCalled_TenantIdShouldBeAvailable()
+    {
+        await RunAzureCliCommand("az account show", response =>
+        {
+            Assert.That(response["tenantId"]?.GetValue<string>(),
+                Is.EqualTo(GlobalSettings.DefaultTenantId).IgnoreCase);
+        });
+    }
+}

--- a/Topaz.Tests/E2E/SubscriptionTests.cs
+++ b/Topaz.Tests/E2E/SubscriptionTests.cs
@@ -2,6 +2,7 @@ using Topaz.CLI;
 using Azure.ResourceManager;
 using Topaz.Identity;
 using Topaz.ResourceManager;
+using Topaz.Shared;
 
 namespace Topaz.Tests.E2E;
 
@@ -44,6 +45,40 @@ public class SubscriptionTests
             Assert.That(subscription.Data.SubscriptionId, Is.EqualTo(Guid.Empty.ToString()));
             Assert.That(subscription.Data.DisplayName, Is.EqualTo("sub-test"));
         });
+    }
+
+    [Test]
+    public async Task SubscriptionTests_WhenSubscriptionIsRequested_TenantIdShouldBeAvailable()
+    {
+        // Arrange
+        var subscriptionId = Guid.NewGuid().ToString();
+        await Program.RunAsync(
+        [
+            "subscription",
+            "delete",
+            "--id",
+            subscriptionId
+        ]);
+
+        await Program.RunAsync(
+        [
+            "subscription",
+            "create",
+            "--id",
+            subscriptionId,
+            "--name",
+            "sub-test"
+        ]);
+
+        var credentials = new AzureLocalCredential(Globals.GlobalAdminId);
+        var armClient = new ArmClient(credentials, subscriptionId, ArmClientOptions);
+
+        // Act
+        var subscription = await armClient.GetSubscriptions().GetAsync(subscriptionId);
+
+        // Assert
+        Assert.That(subscription.Value.Data.TenantId,
+            Is.EqualTo(Guid.Parse(GlobalSettings.DefaultTenantId)));
     }
 
     [Test]


### PR DESCRIPTION
## What

Adds `TenantId` to two model classes so that `subscription().tenantId` resolves in ARM templates and `GET /subscriptions/{id}` returns the field — closes #162.

## Why

Per the issue: `subscription().tenantId` is documented and returned by real Azure but currently throws in Topaz with "The language expression property 'tenantId' doesn't exist, available properties are 'id, subscriptionId, displayName'." This blocks any Bicep template that defaults `tenantId` from `subscription().tenantId` — common in Key Vault and Managed Identity templates.

## How

- `SubscriptionMetadata.cs` (the JSON object the ARM template engine evaluates `subscription()` against): add `TenantId` property, default to `GlobalSettings.DefaultTenantId` in the constructor.
- `Subscription.cs` (the REST resource model): same — adds `TenantId` with the same default.
- `GetSubscriptionResponse.cs`: propagate the new field from the model.

Both defaults use `GlobalSettings.DefaultTenantId`, matching the pattern that `ManagementGroup` and `HierarchySettings` already follow for their `TenantId` fields. No new configuration surface; the value Topaz already uses internally is simply surfaced where it was missing.

`ListSubscriptionsResponse` uses the `Subscription` model directly, so the field shows up there automatically.

## Tests

- `Topaz.Tests/E2E/SubscriptionTests.cs` — new `SubscriptionTests_WhenSubscriptionIsRequested_TenantIdShouldBeAvailable` asserts the Azure SDK reads `TenantId` off the subscription resource.
- `Topaz.Tests.AzureCLI/SubscriptionTests.cs` — new file, asserts `az account show` returns `tenantId`.

Validated locally in WSL2 Ubuntu 22.04 with .NET 10.0.300: the new test passes, all 16 `SubscriptionTests` pass, no regression in `ResourceManagerTests` / `WhatIfDeploymentTests` / `ScenariosTests`.

## Scope notes

Kept the change minimal: tenant id is a hardcoded constant, same as in the rest of the codebase. Making it configurable per subscription (multi-tenant emulation) felt like a separate design conversation and would balloon scope; happy to follow up if useful.
