### PR TITLE
Improve the CLI error message when it looks like topaz-host is not running

### DIFF
--- a/Topaz.CLI/Program.cs
+++ b/Topaz.CLI/Program.cs
@@ -93,16 +93,18 @@ internal class Program
             return 0;
 
         }
-        catch (HttpRequestException)
+        catch (HttpRequestException ex)
         {
             await Console.Error.WriteLineAsync(
-                "Topaz Host is not running. Please start it first using `topaz-host`.");
+                "Topaz Host is not running. Please start it first using `topaz-host`.\n" +
+                $"Error: {ex.Message}");
             return 1;
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex)
         {
             await Console.Error.WriteLineAsync(
-                "Topaz Host is not running. Please start it first using `topaz-host`.");
+                "Topaz Host is not running. Please start it first using `topaz-host`.\n" +
+                $"Error: {ex.Message}");
             return 1;
         }
     }


### PR DESCRIPTION
## Summary

I was just trying to get topaz-host/topaz running and the CLI kept saying topaz-host wasn't running, when it was. The problem was the DNS (`topaz.local.dev` was not routed to localhost). I'm opening this PR to consider the possibility of making this error clearer

## Type of change

- [x] Bug fix
- [ ] New API endpoint
- [ ] New Azure service
- [ ] Enhancement to existing functionality
- [ ] Documentation / API coverage update only
- [ ] Other (describe below)

---

## Checklist

### Every PR
- [x] The build passes (`dotnet build Topaz.sln`)
- [x] Tests pass (`dotnet test Topaz.sln`)
- [x] No hardcoded ports — `GlobalSettings.*Port` constants used throughout

### Contributor
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have signed the CLA (the CLA Assistant bot will prompt me if not)
