### PR TITLE
fix(servicebus): keep the filter when a subscription rule is created through ARM

### DIFF
--- a/Services/Topaz.Service.ServiceBus/Endpoints/Topic/CreateOrUpdateServiceBusRuleEndpoint.cs
+++ b/Services/Topaz.Service.ServiceBus/Endpoints/Topic/CreateOrUpdateServiceBusRuleEndpoint.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Topaz.EventPipeline;
 using Topaz.Service.ServiceBus.Models;
+using Topaz.Service.ServiceBus.Models.Requests;
 using Topaz.Service.Shared;
 using Topaz.Service.Shared.Domain;
 using Topaz.Shared;
@@ -39,8 +40,9 @@ internal sealed class CreateOrUpdateServiceBusRuleEndpoint(Pipeline eventPipelin
 
         using var reader = new StreamReader(context.Request.Body);
         var content = reader.ReadToEnd();
-        var properties = JsonSerializer.Deserialize<ServiceBusRuleResourceProperties>(content,
-            GlobalSettings.JsonOptions) ?? ServiceBusRuleResourceProperties.DefaultTrueFilter();
+        var request = JsonSerializer.Deserialize<CreateOrUpdateServiceBusRuleRequest>(content,
+            GlobalSettings.JsonOptions);
+        var properties = request?.Properties ?? ServiceBusRuleResourceProperties.DefaultTrueFilter();
 
         var operation = _controlPlane.CreateOrUpdateRule(subscriptionIdentifier, resourceGroupIdentifier,
             namespaceName, topicName, subscriptionName, ruleName, properties);

--- a/Services/Topaz.Service.ServiceBus/Models/Requests/CreateOrUpdateServiceBusRuleRequest.cs
+++ b/Services/Topaz.Service.ServiceBus/Models/Requests/CreateOrUpdateServiceBusRuleRequest.cs
@@ -1,0 +1,22 @@
+using Topaz.ResourceManager;
+
+namespace Topaz.Service.ServiceBus.Models.Requests;
+
+/// <summary>
+/// The ARM envelope for a rule create-or-update. The control plane receives
+/// <c>{"properties":{"filterType":…}}</c>, so the filter lives one level down — deserializing the body
+/// straight into <see cref="ServiceBusRuleResourceProperties"/> binds nothing and silently falls back to
+/// that type's defaults.
+/// </summary>
+public sealed class CreateOrUpdateServiceBusRuleRequest
+{
+    public ServiceBusRuleResourceProperties? Properties { get; init; } = new();
+
+    public static CreateOrUpdateServiceBusRuleRequest From(GenericResource resource)
+    {
+        return new CreateOrUpdateServiceBusRuleRequest
+        {
+            Properties = resource.Properties as ServiceBusRuleResourceProperties
+        };
+    }
+}

--- a/Services/Topaz.Service.ServiceBus/Models/ServiceBusRuleResourceProperties.cs
+++ b/Services/Topaz.Service.ServiceBus/Models/ServiceBusRuleResourceProperties.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Topaz.Service.ServiceBus.Models;
 
 public sealed class ServiceBusSqlRuleFilter
@@ -15,7 +17,15 @@ public sealed class ServiceBusCorrelationRuleFilter
     public string? ReplyTo { get; set; }
     public string? ReplyToSessionId { get; set; }
     public string? SessionId { get; set; }
+
+    /// <summary>
+    /// The message Subject. ARM calls this <c>label</c> — there is no <c>subject</c> in the
+    /// correlationFilter contract — so a rule deployed from a template that filters on the native
+    /// Subject binds nothing without this name.
+    /// </summary>
+    [JsonPropertyName("label")]
     public string? Subject { get; set; }
+
     public string? To { get; set; }
     public bool RequiresPreprocessing { get; set; } = true;
     public Dictionary<string, string>? Properties { get; set; }

--- a/Tests/Topaz.Tests/E2E/ServiceBusRuleArmTests.cs
+++ b/Tests/Topaz.Tests/E2E/ServiceBusRuleArmTests.cs
@@ -1,0 +1,137 @@
+using Azure.Messaging.ServiceBus.Administration;
+using Azure.ResourceManager;
+using Azure.ResourceManager.ServiceBus;
+using Azure.ResourceManager.ServiceBus.Models;
+using Topaz.CLI;
+using Topaz.Identity;
+using Topaz.ResourceManager;
+
+namespace Topaz.Tests.E2E;
+
+/// <summary>
+/// Subscription rules created through the <b>Resource Manager</b> API, which is the path ARM templates,
+/// Bicep and <c>az deployment</c> take.
+///
+/// <para>
+/// <see cref="ServiceBusRuleTests"/> and <see cref="TopicSubscriptionRuleFilteringTests"/> both drive
+/// <c>ServiceBusAdministrationClient</c>, which reaches the Atom endpoint. That endpoint converts the
+/// request through <c>CreateOrUpdateServiceBusRuleAtomRequest.ToProperties</c> and has always worked; the
+/// ARM endpoint had no coverage, and was deserializing the whole <c>{"properties":{…}}</c> envelope into
+/// the properties type — so every filter was dropped and the rule fell back to an empty SqlFilter.
+/// </para>
+/// </summary>
+public class ServiceBusRuleArmTests
+{
+    private static readonly ArmClientOptions ArmClientOptions = TopazArmClientOptions.New;
+    private static readonly Guid SubscriptionId = Guid.Parse("D2B3C4E5-F6A7-8901-BCDE-F23456789012");
+
+    private const string SubscriptionName = "sub-sb-rule-arm-test";
+    private const string ResourceGroupName = "rg-sb-rule-arm-test";
+    private const string NamespaceName = "sb-rule-arm-test";
+    private const string TopicName = "rule-arm-topic";
+    private const string TopicSubscriptionName = "rule-arm-subscription";
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await Program.RunAsync(["subscription", "delete", "--id", SubscriptionId.ToString()]);
+        await Program.RunAsync(["subscription", "create", "--id", SubscriptionId.ToString(), "--name", SubscriptionName]);
+        await Program.RunAsync(["group", "delete", "--name", ResourceGroupName, "--subscription-id", SubscriptionId.ToString()]);
+        await Program.RunAsync(["group", "create", "--name", ResourceGroupName, "--location", "westeurope", "--subscription-id", SubscriptionId.ToString()]);
+        await Program.RunAsync(["servicebus", "namespace", "delete", "--name", NamespaceName, "--resource-group", ResourceGroupName, "--subscription-id", SubscriptionId.ToString()]);
+        await Program.RunAsync(["servicebus", "namespace", "create", "--name", NamespaceName, "--resource-group", ResourceGroupName, "--location", "westeurope", "--subscription-id", SubscriptionId.ToString()]);
+
+        var adminClient = new ServiceBusAdministrationClient(
+            TopazResourceHelpers.GetServiceBusConnectionStringForManagement(NamespaceName));
+        await adminClient.CreateTopicAsync(TopicName);
+        await adminClient.CreateSubscriptionAsync(new CreateSubscriptionOptions(TopicName, TopicSubscriptionName));
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await Program.RunAsync(["subscription", "delete", "--id", SubscriptionId.ToString()]);
+    }
+
+    private async Task<ServiceBusRuleCollection> GetRules()
+    {
+        var credential = new AzureLocalCredential(Globals.GlobalAdminId);
+        var armClient = new ArmClient(credential, SubscriptionId.ToString(), ArmClientOptions);
+
+        var subscription = await armClient.GetDefaultSubscriptionAsync();
+        var resourceGroup = await subscription.GetResourceGroupAsync(ResourceGroupName);
+        var serviceBusNamespace = (await resourceGroup.Value.GetServiceBusNamespaces().GetAsync(NamespaceName)).Value;
+        var topic = (await serviceBusNamespace.GetServiceBusTopics().GetAsync(TopicName)).Value;
+        var topicSubscription = (await topic.GetServiceBusSubscriptions().GetAsync(TopicSubscriptionName)).Value;
+
+        return topicSubscription.GetServiceBusRules();
+    }
+
+    [Test]
+    public async Task CreateRuleViaArm_ShouldPersistCorrelationFilterProperties()
+    {
+        var rules = await GetRules();
+
+        var data = new ServiceBusRuleData
+        {
+            FilterType = ServiceBusFilterType.CorrelationFilter,
+            CorrelationFilter = new ServiceBusCorrelationFilter()
+        };
+        data.CorrelationFilter.ApplicationProperties.Add("PayloadType", "InventoryAdjusted");
+
+        await rules.CreateOrUpdateAsync(Azure.WaitUntil.Completed, "correlation-rule", data);
+
+        var stored = (await rules.GetAsync("correlation-rule")).Value.Data;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stored.FilterType, Is.EqualTo(ServiceBusFilterType.CorrelationFilter));
+            Assert.That(stored.CorrelationFilter, Is.Not.Null);
+            Assert.That(stored.CorrelationFilter.ApplicationProperties["PayloadType"], Is.EqualTo("InventoryAdjusted"));
+        });
+    }
+
+    [Test]
+    public async Task CreateRuleViaArm_ShouldPersistCorrelationFilterSubject()
+    {
+        var rules = await GetRules();
+
+        var data = new ServiceBusRuleData
+        {
+            FilterType = ServiceBusFilterType.CorrelationFilter,
+            CorrelationFilter = new ServiceBusCorrelationFilter { Subject = "InventoryAdjusted" }
+        };
+
+        await rules.CreateOrUpdateAsync(Azure.WaitUntil.Completed, "subject-rule", data);
+
+        var stored = (await rules.GetAsync("subject-rule")).Value.Data;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stored.FilterType, Is.EqualTo(ServiceBusFilterType.CorrelationFilter));
+            Assert.That(stored.CorrelationFilter?.Subject, Is.EqualTo("InventoryAdjusted"));
+        });
+    }
+
+    [Test]
+    public async Task CreateRuleViaArm_ShouldPersistSqlFilterExpression()
+    {
+        var rules = await GetRules();
+
+        var data = new ServiceBusRuleData
+        {
+            FilterType = ServiceBusFilterType.SqlFilter,
+            SqlFilter = new ServiceBusSqlFilter { SqlExpression = "PayloadType = 'InventoryAdjusted'" }
+        };
+
+        await rules.CreateOrUpdateAsync(Azure.WaitUntil.Completed, "sql-rule", data);
+
+        var stored = (await rules.GetAsync("sql-rule")).Value.Data;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(stored.FilterType, Is.EqualTo(ServiceBusFilterType.SqlFilter));
+            Assert.That(stored.SqlFilter?.SqlExpression, Is.EqualTo("PayloadType = 'InventoryAdjusted'"));
+        });
+    }
+}


### PR DESCRIPTION
Fixes #312.

## The bug

`CreateOrUpdateServiceBusRuleEndpoint` deserialized the whole ARM request body into
`ServiceBusRuleResourceProperties`:

```csharp
var properties = JsonSerializer.Deserialize<ServiceBusRuleResourceProperties>(content, GlobalSettings.JsonOptions)
    ?? ServiceBusRuleResourceProperties.DefaultTrueFilter();
```

ARM sends `{"properties":{"filterType":…,"correlationFilter":{…}}}`, so `filterType` sits one level below
where that bind is looking. Nothing matched, and the type's own defaults were persisted instead —
`FilterType = "SqlFilter"` with both `SqlFilter` and `CorrelationFilter` left `null`.

Every rule created through ARM ended up with no filter at all. `TopicSubscriptionRuleEvaluator` then had
nothing to evaluate, so a topic could not route to its subscriptions. The call returned `200` throughout,
which is what made it hard to spot.

## The fix

Adds `CreateOrUpdateServiceBusRuleRequest` and binds to that instead. It mirrors the existing
`CreateOrUpdateServiceBusSubscriptionRequest` / `CreateOrUpdateServiceBusTopicRequest` wrappers — Rule was
the only ARM entity in this service without one, which looks like how the gap crept in.

The routing engine itself needed no change. `FanOutToSubscriptions`, `TopicSubscriptionRuleEvaluator` and
`SqlRuleActionApplicator` were all working; they were just being handed empty rules.

## Why the existing tests missed it

`ServiceBusRuleTests` and `TopicSubscriptionRuleFilteringTests` both drive
`ServiceBusAdministrationClient`, which reaches the **Atom** endpoint. That path converts through
`CreateOrUpdateServiceBusRuleAtomRequest.ToProperties` and has always been correct. The **ARM** path — what
ARM templates, Bicep and `az deployment` use — had no coverage.

`ServiceBusRuleArmTests` adds it, going through `ArmClient` like `ServiceBusAuthorizationRuleTests` does:
correlation filter by application property, correlation filter by `Subject`, and a SQL filter expression.

## Verification

Built the host image from this branch and ran a standalone reproduction against it
([repro repo](https://github.com/ChrisonSimtian/topaz-servicebus-rule-repro)):

Before:
```
PUT  {"properties":{"filterType":"CorrelationFilter","correlationFilter":{"properties":{"PayloadType":"Wanted"}}}}
GET  {"filterType":"SqlFilter"}
```

After:
```
PUT  {"properties":{"filterType":"CorrelationFilter","correlationFilter":{"properties":{"PayloadType":"Wanted"}}}}
GET  {"filterType":"CorrelationFilter","correlationFilter":{"requiresPreprocessing":true,"properties":{"PayloadType":"Wanted"}}}
```

**One caveat worth stating plainly:** `ServiceBusRuleArmTests` compiles and is written to match the
surrounding fixtures, but I could not run the E2E suite locally — it wants Topaz reachable on
`topaz.local.dev` sharing the CLI's data directory, and I was working from a container. Please treat CI as
the first real run of it. Happy to adjust if it needs anything.

## Not covered here

Two smaller things noticed while investigating, left alone to keep this focused — glad to raise them
separately if useful:

- `topic.subscriptionCount` stays `0` after a subscription is created.
- `GET .../namespaces/{ns}/topics` returns every Service Bus entity in the namespace (subscriptions and
  rules included, each with its correct `type`) when the namespace was created as a side-effect of an ARM
  deployment. A namespace created by an explicit `PUT` lists correctly.

---

*Investigated and authored with AI assistance (Claude Opus 5); the before/after above was reproduced against
a locally built image from this branch.*
