### PR TITLE
fix(deployments): deploy a nested deployment into its parent resource group

### DIFF
--- a/Services/Topaz.Service.ResourceManager/Deployment/TemplateDeploymentOrchestrator.cs
+++ b/Services/Topaz.Service.ResourceManager/Deployment/TemplateDeploymentOrchestrator.cs
@@ -514,14 +514,25 @@ public sealed class TemplateDeploymentOrchestrator(
                 return;
             }
 
-            // Extract resourceGroup property
-            if (!resourceObj.TryGetValue("resourceGroup", out var rgElement))
+            // A nested deployment only carries 'resourceGroup' when it targets a different one. Bicep
+            // omits it for a module deployed into its parent's resource group — the common case, and
+            // what every `module x 'y.bicep' = {...}` without an explicit scope compiles to. Falling
+            // back to the parent's group makes those deploy instead of being silently skipped.
+            var parentIdParts = parentDeployment.Id.TrimStart('/').Split('/');
+            var parentRgName = parentIdParts.Length > 3 && parentIdParts[2] == "resourceGroups"
+                ? parentIdParts[3]
+                : null;
+
+            var nestedRgName = resourceObj.TryGetValue("resourceGroup", out var rgElement)
+                ? rgElement.GetString()
+                : parentRgName;
+
+            if (nestedRgName is null)
             {
-                logger.LogWarning($"Nested deployment '{genericResource.Name}' has no 'resourceGroup' property; subscription-scoped nested deployments are not yet supported.");
+                logger.LogWarning($"Nested deployment '{genericResource.Name}' has no 'resourceGroup' property and its parent is not resource-group scoped; subscription-scoped nested deployments are not yet supported.");
                 return;
             }
 
-            var nestedRgName = rgElement.GetString();
             if (string.IsNullOrWhiteSpace(nestedRgName))
             {
                 logger.LogWarning($"Nested deployment '{genericResource.Name}' has empty 'resourceGroup' property.");
@@ -564,7 +575,6 @@ public sealed class TemplateDeploymentOrchestrator(
                 : "Incremental";
 
             // Step 2: Resolve nested context identifiers
-            var parentIdParts = parentDeployment.Id.TrimStart('/').Split('/');
             var nestedSubId = parentIdParts.Length > 1 && parentIdParts[0] == "subscriptions"
                 ? SubscriptionIdentifier.From(parentIdParts[1])
                 : throw new InvalidOperationException($"Cannot extract subscription ID from parent deployment ID: {parentDeployment.Id}");


### PR DESCRIPTION
**Rescoped.** This PR carried three unrelated fixes and a commit belonging to #313. It is now one fix; the rest are their own PRs, listed below.

## The fix

A nested deployment with no `resourceGroup` property was skipped with a warning and no failure, so the parent reported success having created nothing.

Bicep only emits `resourceGroup` when a module targets a different group. Every `module x 'y.bicep' = {...}` without an explicit scope — the common case — compiles without it and hit this. Falls back to the parent deployment's group, and warns only when the parent is not resource-group scoped either.

## Split out of this PR

| | |
|---|---|
| #313 | rule filter dropped when a rule is created through ARM — was in this branch by accident |
| (this) | nested deployment falls back to the parent resource group |
| ↓ | parent resource group location is never read |
| ↓ | ARM ids built by concatenation instead of interleaving |
| ↓ | Service Bus topics, subscriptions and rules unroutable from a template |
| ↓ | `ListTopics` / `ListQueues` return their children as topics and queues |

They are separate PRs rather than a stack because a PR from a fork can only target `main`, so each is rebased to stand alone. Nothing between them conflicts.

One further change — provisioning the resources inside a nested deployment — is deliberately **not** a PR. It makes a design decision that is yours, and regresses nested-deployment outputs. It sits on a branch linked from #205.

---

*This description was written by AI (Claude Opus 5).*
