### PR TITLE
fix(deployments): read the parent resource group location for a nested deployment

### DIFF
--- a/Services/Topaz.Service.ResourceManager/Deployment/TemplateDeploymentOrchestrator.cs
+++ b/Services/Topaz.Service.ResourceManager/Deployment/TemplateDeploymentOrchestrator.cs
@@ -574,9 +574,17 @@ public sealed class TemplateDeploymentOrchestrator(
             // Step 3: Build inner metadata
             var subscriptionMetadata = new SubscriptionMetadata(nestedSubId);
             
-            // Extract parent RG metadata to get location
-            var parentRgMetadata = parentDeployment.Metadata.TryGetValue(DeploymentMetadata.ResourceGroupKey, out var rgMetadataToken)
-                ? JsonSerializer.Deserialize<ResourceGroupMetadata>(rgMetadataToken.ToString(), GlobalSettings.JsonOptions)
+            // Extract the parent resource group's location. Read the property off the token rather than
+            // deserializing ResourceGroupMetadata: that record's only constructor takes identifier types
+            // while its properties are strings, so System.Text.Json cannot bind them and throws. Location
+            // is the only thing needed here.
+            // Case-insensitively: the metadata is serialized with GlobalSettings.JsonOptions, whose
+            // camelCase naming policy does not match the PascalCase property name read here.
+            var parentRgLocation = parentDeployment.Metadata.TryGetValue(DeploymentMetadata.ResourceGroupKey, out var rgMetadataToken)
+                                   && rgMetadataToken is JObject rgMetadataObject
+                ? rgMetadataObject
+                    .GetValue(nameof(ResourceGroupMetadata.Location), StringComparison.OrdinalIgnoreCase)
+                    ?.Value<string>()
                 : null;
 
             AzureLocation nestedLocation;
@@ -584,9 +592,9 @@ public sealed class TemplateDeploymentOrchestrator(
             {
                 nestedLocation = new AzureLocation(genericResource.Location);
             }
-            else if (parentRgMetadata?.Location != null)
+            else if (!string.IsNullOrWhiteSpace(parentRgLocation))
             {
-                nestedLocation = parentRgMetadata.Location;
+                nestedLocation = new AzureLocation(parentRgLocation);
             }
             else if (parentDeployment.Metadata.TryGetValue(DeploymentMetadata.LocationKey, out var parentLocationToken)
                      && parentLocationToken.Type == JTokenType.String


### PR DESCRIPTION
Split out of #314.

A nested deployment that inherits its location from the parent resource group never gets one. Two defects on the same path, either of which is enough on its own:

1. **`JsonSerializer.Deserialize<ResourceGroupMetadata>` throws.** The record's only constructor takes identifier types while its properties are strings, so `System.Text.Json` cannot bind them.
2. **The property lookup misses.** Reading `Location` off the token instead, PascalCase does not match: the metadata is serialized with `GlobalSettings.JsonOptions`, whose camelCase policy writes `location`.

Both end at `Nested deployment '...' has no location and parent location cannot be resolved.`

`Location` is the only value taken from that metadata, so this reads it off the `JToken` case-insensitively rather than materialising the record.

Independent of #314 and of the other three split out of it — rebased onto `main` so each stands alone.

---

*This description was written by AI (Claude Opus 5).*
