### PR TITLE
fix(deployments): build ARM ids by interleaving type and name segments

### DIFF
--- a/Services/Topaz.Service.ApiManagement/Models/ApiContractResource.cs
+++ b/Services/Topaz.Service.ApiManagement/Models/ApiContractResource.cs
@@ -110,7 +110,8 @@ internal sealed class ApiContractResource : ArmSubresource<ApiContractResourcePr
 
     public override string GetParentId()
     {
+        // The APIM instance name: /…/providers/Microsoft.ApiManagement/service/{apim}/{child}/{name}
         var segments = Id.Split("/");
-        return segments[9];
+        return segments[8];
     }
 }

--- a/Services/Topaz.Service.ApiManagement/Models/BackendContractResource.cs
+++ b/Services/Topaz.Service.ApiManagement/Models/BackendContractResource.cs
@@ -79,7 +79,8 @@ internal sealed class BackendContractResource : ArmSubresource<BackendContractRe
     
     public override string GetParentId()
     {
+        // The APIM instance name: /…/providers/Microsoft.ApiManagement/service/{apim}/{child}/{name}
         var segments = Id.Split("/");
-        return segments[9];
+        return segments[8];
     }
 }

--- a/Services/Topaz.Service.ApiManagement/Models/PolicyContractResource.cs
+++ b/Services/Topaz.Service.ApiManagement/Models/PolicyContractResource.cs
@@ -49,7 +49,8 @@ internal sealed class PolicyContractResource : ArmSubresource<PolicyContractReso
     
     public override string GetParentId()
     {
+        // The APIM instance name: /…/providers/Microsoft.ApiManagement/service/{apim}/{child}/{name}
         var segments = Id.Split("/");
-        return segments[9];
+        return segments[8];
     }
 }

--- a/Services/Topaz.Service.ApiManagement/Models/ProductContractResource.cs
+++ b/Services/Topaz.Service.ApiManagement/Models/ProductContractResource.cs
@@ -66,7 +66,8 @@ internal sealed class ProductContractResource : ArmSubresource<ProductContractRe
     
     public override string GetParentId()
     {
+        // The APIM instance name: /…/providers/Microsoft.ApiManagement/service/{apim}/{child}/{name}
         var segments = Id.Split("/");
-        return segments[9];
+        return segments[8];
     }
 }

--- a/Services/Topaz.Service.ApiManagement/Models/SubscriptionContractResource.cs
+++ b/Services/Topaz.Service.ApiManagement/Models/SubscriptionContractResource.cs
@@ -38,7 +38,8 @@ internal sealed class SubscriptionContractResource : ArmSubresource<Subscription
     
     public override string GetParentId()
     {
+        // The APIM instance name: /…/providers/Microsoft.ApiManagement/service/{apim}/{child}/{name}
         var segments = Id.Split("/");
-        return segments[9];
+        return segments[8];
     }
 }

--- a/Services/Topaz.Service.ResourceManager/Deployment/TemplateDeploymentOrchestrator.cs
+++ b/Services/Topaz.Service.ResourceManager/Deployment/TemplateDeploymentOrchestrator.cs
@@ -66,7 +66,7 @@ public sealed class TemplateDeploymentOrchestrator(
         {
             resource.Id = new TemplateGenericProperty<string>
             {
-                Value = $"/subscriptions/{subscriptionIdentifier}/resourceGroups/{resourceGroupIdentifier}/providers/{resource.Type.Value}/{resource.Name.Value}"
+                Value = ArmResourceId.Build($"/subscriptions/{subscriptionIdentifier}/resourceGroups/{resourceGroupIdentifier}", resource.Type.Value, resource.Name.Value)
             };
         }
 
@@ -108,7 +108,7 @@ public sealed class TemplateDeploymentOrchestrator(
             {
                 resource.Id = new TemplateGenericProperty<string>
                 {
-                    Value = $"/subscriptions/{subscriptionIdentifier}/providers/{resource.Type.Value}/{resource.Name.Value}"
+                    Value = ArmResourceId.Build($"/subscriptions/{subscriptionIdentifier}", resource.Type.Value, resource.Name.Value)
                 };
             }
         }
@@ -140,7 +140,7 @@ public sealed class TemplateDeploymentOrchestrator(
         {
             resource.Id = new TemplateGenericProperty<string>
             {
-                Value = $"/providers/{resource.Type.Value}/{resource.Name.Value}"
+                Value = ArmResourceId.Build(string.Empty, resource.Type.Value, resource.Name.Value)
             };
         }
 
@@ -171,7 +171,7 @@ public sealed class TemplateDeploymentOrchestrator(
         {
             resource.Id = new TemplateGenericProperty<string>
             {
-                Value = $"/providers/{resource.Type.Value}/{resource.Name.Value}"
+                Value = ArmResourceId.Build(string.Empty, resource.Type.Value, resource.Name.Value)
             };
         }
 

--- a/Services/Topaz.Service.ResourceManager/ResourceManagerControlPlane.cs
+++ b/Services/Topaz.Service.ResourceManager/ResourceManagerControlPlane.cs
@@ -230,7 +230,7 @@ internal sealed class ResourceManagerControlPlane(
             {
                 resource.Id = new TemplateGenericProperty<string>
                 {
-                    Value = $"/subscriptions/{subscriptionIdentifier}/resourceGroups/{resourceGroupIdentifier}/providers/{resource.Type.Value}/{resource.Name.Value}"
+                    Value = ArmResourceId.Build($"/subscriptions/{subscriptionIdentifier}/resourceGroups/{resourceGroupIdentifier}", resource.Type.Value, resource.Name.Value)
                 };
             }
 
@@ -318,7 +318,7 @@ internal sealed class ResourceManagerControlPlane(
             var afterNodes = new Dictionary<string, JsonNode>(StringComparer.OrdinalIgnoreCase);
             foreach (var r in template.Resources)
             {
-                var id = $"/providers/{r.Type.Value}/{r.Name.Value}";
+                var id = ArmResourceId.Build(string.Empty, r.Type.Value, r.Name.Value);
                 var node = JsonNode.Parse(r.ToJson());
                 if (node == null) continue;
                 StripArmExpressionsFromNode(node);
@@ -385,7 +385,7 @@ internal sealed class ResourceManagerControlPlane(
         {
             var id = isSubscriptionScope
                 ? BuildSubscriptionScopeId(subscriptionIdentifier, r.Type.Value, r.Name.Value)
-                : $"/subscriptions/{subscriptionIdentifier}/resourceGroups/{resourceGroupIdentifier}/providers/{r.Type.Value}/{r.Name.Value}";
+                : ArmResourceId.Build($"/subscriptions/{subscriptionIdentifier}/resourceGroups/{resourceGroupIdentifier}", r.Type.Value, r.Name.Value);
 
             var node = JsonNode.Parse(r.ToJson());
             if (node == null) continue;
@@ -538,7 +538,7 @@ internal sealed class ResourceManagerControlPlane(
         SubscriptionIdentifier subscriptionIdentifier, string type, string name) =>
         type.Equals("Microsoft.Resources/resourceGroups", StringComparison.OrdinalIgnoreCase)
             ? $"/subscriptions/{subscriptionIdentifier}/resourceGroups/{name}"
-            : $"/subscriptions/{subscriptionIdentifier}/providers/{type}/{name}";
+            : ArmResourceId.Build($"/subscriptions/{subscriptionIdentifier}", type, name);
 
     private IEnumerable<GenericResource> CollectResourcesAtSubscriptionScope(
         SubscriptionIdentifier subscriptionIdentifier)

--- a/Tests/Topaz.Tests.Unit/ResourceManager/ArmResourceIdTests.cs
+++ b/Tests/Topaz.Tests.Unit/ResourceManager/ArmResourceIdTests.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+using Topaz.ResourceManager;
+
+namespace Topaz.Tests.Unit.ResourceManager;
+
+[TestFixture]
+public class ArmResourceIdTests
+{
+    private const string ResourceGroupScope =
+        "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg";
+
+    [Test]
+    public void Build_PairsEachTypeSegmentWithItsNameSegment()
+    {
+        var id = ArmResourceId.Build(
+            ResourceGroupScope, "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules", "ns/topic/sub/rule");
+
+        Assert.That(id, Is.EqualTo(
+            $"{ResourceGroupScope}/providers/Microsoft.ServiceBus/namespaces/ns/topics/topic/subscriptions/sub/rules/rule"));
+    }
+
+    [Test]
+    public void Build_LeavesATopLevelResourceUnchanged()
+    {
+        var id = ArmResourceId.Build(ResourceGroupScope, "Microsoft.ServiceBus/namespaces", "ns");
+
+        Assert.That(id, Is.EqualTo($"{ResourceGroupScope}/providers/Microsoft.ServiceBus/namespaces/ns"));
+    }
+
+    [Test]
+    public void Build_HangsOffAnEmptyScopeAtTenantLevel()
+    {
+        var id = ArmResourceId.Build(string.Empty, "Microsoft.Management/managementGroups", "mg");
+
+        Assert.That(id, Is.EqualTo("/providers/Microsoft.Management/managementGroups/mg"));
+    }
+
+    /// <summary>
+    /// A name that does not pair with the type is left as it was rather than guessed at, so a
+    /// malformed template produces a recognisably wrong id instead of a plausible one.
+    /// </summary>
+    [TestCase("Microsoft.ServiceBus/namespaces/topics", "topic")]
+    [TestCase("Microsoft.ServiceBus/namespaces", "ns/topic")]
+    public void Build_FallsBackWhenTypeAndNameDoNotPair(string type, string name)
+    {
+        var id = ArmResourceId.Build(ResourceGroupScope, type, name);
+
+        Assert.That(id, Is.EqualTo($"{ResourceGroupScope}/providers/{type}/{name}"));
+    }
+}

--- a/Tests/Topaz.Tests.Unit/Topaz.Tests.Unit.csproj
+++ b/Tests/Topaz.Tests.Unit/Topaz.Tests.Unit.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Services/Topaz.Service.CosmosDb/Topaz.Service.CosmosDb.csproj" />
+    <ProjectReference Include="../../Topaz.ResourceManager/Topaz.ResourceManager.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Topaz.ResourceManager/ArmResourceId.cs
+++ b/Topaz.ResourceManager/ArmResourceId.cs
@@ -1,0 +1,39 @@
+using System.Text;
+
+namespace Topaz.ResourceManager;
+
+public static class ArmResourceId
+{
+    /// <summary>
+    /// Builds the ARM id for a resource from its type and name, which interleave: type
+    /// <c>Microsoft.ServiceBus/namespaces/topics</c> with name <c>ns/topic</c> gives
+    /// <c>{scope}/providers/Microsoft.ServiceBus/namespaces/ns/topics/topic</c>.
+    ///
+    /// <para>
+    /// Concatenating the two instead puts a type keyword where a resource name belongs, so every
+    /// child lookup resolves against the wrong parent. Only resources whose type has a single
+    /// segment after the provider are unaffected, which is why this is invisible until a template
+    /// declares a child resource.
+    /// </para>
+    /// </summary>
+    /// <param name="scope">
+    /// The id prefix the resource hangs off, with no trailing slash — for example
+    /// <c>/subscriptions/{id}/resourceGroups/{name}</c>, or an empty string at tenant scope.
+    /// </param>
+    public static string Build(string scope, string? type, string? name)
+    {
+        var typeSegments = (type ?? string.Empty).Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var nameSegments = (name ?? string.Empty).Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        // typeSegments[0] is the provider namespace; the rest pair up with the name segments.
+        // Anything that does not pair is left as it was rather than guessed at.
+        if (typeSegments.Length < 2 || typeSegments.Length - 1 != nameSegments.Length)
+            return $"{scope}/providers/{type}/{name}";
+
+        var id = new StringBuilder(scope).Append("/providers/").Append(typeSegments[0]);
+        for (var i = 0; i < nameSegments.Length; i++)
+            id.Append('/').Append(typeSegments[i + 1]).Append('/').Append(nameSegments[i]);
+
+        return id.ToString();
+    }
+}


### PR DESCRIPTION
Split out of #314.

A resource id was built as `{scope}/providers/{type}/{name}`. That is correct only while the type has a single segment after the provider. For a child resource the type and name **interleave**:

```
type  Microsoft.ServiceBus/namespaces/topics
name  ns/topic

now   …/providers/Microsoft.ServiceBus/namespaces/ns/topics/topic
was   …/providers/Microsoft.ServiceBus/namespaces/topics/ns/topic
```

The concatenated form puts a type keyword where a resource name belongs. Anything that reads a name back out of an id then resolves against the wrong parent — `ServiceBusQueueResource.GetNamespace()` and its peers take segment 8, which lands on `topics` rather than the namespace. Invisible until a template declares a child resource, which is why it has gone unnoticed.

Extracted as `ArmResourceId.Build` and applied at every site that builds one: the four `Enqueue*Deployment` scopes and the three what-if paths. A type and name that do not pair produce the previous shape rather than a guess, so a malformed template gives a recognisably wrong id instead of a plausible one.

Five unit tests in `Topaz.Tests.Unit`, covering a child chain four levels deep, a top-level resource, tenant scope and both non-pairing shapes.

Independent of #314 and of the other three split out of it — rebased onto `main` so each stands alone.

---

*This description was written by AI (Claude Opus 5).*
