### PR TITLE
fix(servicebus): list topics and queues shallowly

### DIFF
--- a/Services/Topaz.Service.ServiceBus/ServiceBusServiceControlPlane.cs
+++ b/Services/Topaz.Service.ServiceBus/ServiceBusServiceControlPlane.cs
@@ -519,7 +519,9 @@ internal sealed class ServiceBusServiceControlPlane(
                 namespacesOperation.Reason, namespacesOperation.Code);
         }
 
-        var queues = provider.ListSubresourcesAs<ServiceBusQueueResource>(subscriptionIdentifier,
+        // Shallow: a queue's authorization rules live in folders under the queue, and a recursive
+        // listing returns each of them as though it were another queue.
+        var queues = provider.ListSubresourcesShallowAs<ServiceBusQueueResource>(subscriptionIdentifier,
             resourceGroupIdentifier, serviceBusNamespaceIdentifier.Value,
             nameof(Subresource.Queues).ToLowerInvariant());
 
@@ -544,14 +546,16 @@ internal sealed class ServiceBusServiceControlPlane(
                 namespacesOperation.Reason, namespacesOperation.Code);
         }
 
-        var queues = provider.ListSubresourcesAs<ServiceBusTopicResource>(subscriptionIdentifier,
+        // Shallow: subscriptions, their rules and the topic's authorization rules are all stored in
+        // folders under the topic, and a recursive listing returns every one of them as a topic.
+        var topics = provider.ListSubresourcesShallowAs<ServiceBusTopicResource>(subscriptionIdentifier,
             resourceGroupIdentifier, serviceBusNamespaceIdentifier.Value,
             nameof(Subresource.Topics).ToLowerInvariant());
 
-        logger.LogDebug(nameof(ServiceBusServiceControlPlane), nameof(ListTopics), "Found {0} queues.", queues.Length);
+        logger.LogDebug(nameof(ServiceBusServiceControlPlane), nameof(ListTopics), "Found {0} topics.", topics.Length);
 
         return new ControlPlaneOperationResult<ServiceBusTopicResource[]>(OperationResult.Success,
-            queues.ToArray());
+            topics.ToArray());
     }
 
     private static string RulesParentId(ServiceBusNamespaceIdentifier namespaceIdentifier, string topicName, string subscriptionName) =>


### PR DESCRIPTION
Split out of #314.

`ListTopics` and `ListQueues` use `ListSubresourcesAs`, which walks `SearchOption.AllDirectories`. Subscriptions, their rules, and authorization rules are all stored in folders under their parent, so every one of them is deserialized as another topic or queue.

A namespace with one topic, five subscriptions and their rules lists **sixteen topics**:

```
TOPIC ErpBodMessages
TOPIC InventoryAdjustmentBodProcessor     ← a subscription
TOPIC CustomCorrelationRule               ← a rule
TOPIC $Default                            ← a rule
...
```

`ListSubscriptions` already reads only the immediate children via `ListSubresourcesShallowAs`. These two now do the same. No new provider API — the shallow variant exists for exactly this.

Independent of #314 and of the other three split out of it — rebased onto `main` so each stands alone.

---

*This description was written by AI (Claude Opus 5).*
